### PR TITLE
TST, MAINT: test mingw32ccompiler.build_import, tweak lib2def

### DIFF
--- a/numpy/distutils/lib2def.py
+++ b/numpy/distutils/lib2def.py
@@ -63,9 +63,9 @@ def getnm(nm_cmd=['nm', '-Cs', 'python%s.lib' % py_ver], shell=True):
     """Returns the output of nm_cmd via a pipe.
 
 nm_output = getnam(nm_cmd = 'nm -Cs py_lib')"""
-    f = subprocess.Popen(nm_cmd, shell=shell, stdout=subprocess.PIPE, universal_newlines=True)
-    nm_output = f.stdout.read()
-    f.stdout.close()
+    p = subprocess.Popen(nm_cmd, shell=shell, stdout=subprocess.PIPE,
+                         stderr=subprocess.PIPE, universal_newlines=True)
+    nm_output, nm_err = p.communicate()
     return nm_output
 
 def parse_nm(nm_output):

--- a/numpy/distutils/lib2def.py
+++ b/numpy/distutils/lib2def.py
@@ -62,10 +62,13 @@ libfile, deffile = parse_cmd()"""
 def getnm(nm_cmd=['nm', '-Cs', 'python%s.lib' % py_ver], shell=True):
     """Returns the output of nm_cmd via a pipe.
 
-nm_output = getnam(nm_cmd = 'nm -Cs py_lib')"""
+nm_output = getnm(nm_cmd = 'nm -Cs py_lib')"""
     p = subprocess.Popen(nm_cmd, shell=shell, stdout=subprocess.PIPE,
                          stderr=subprocess.PIPE, universal_newlines=True)
     nm_output, nm_err = p.communicate()
+    if p.returncode() != 0:
+        raise RuntimeError('failed to run "%s": "%s"' % (
+                                    ' '.join(nm_cmd), nm_err))
     return nm_output
 
 def parse_nm(nm_output):
@@ -73,6 +76,7 @@ def parse_nm(nm_output):
 symbols and flist for the list of function symbols.
 
 dlist, flist = parse_nm(nm_output)"""
+    import pdb;pdb.set_trace()
     data = DATA_RE.findall(nm_output)
     func = FUNC_RE.findall(nm_output)
 

--- a/numpy/distutils/mingw32ccompiler.py
+++ b/numpy/distutils/mingw32ccompiler.py
@@ -502,7 +502,8 @@ def _build_import_library_x86():
     nm_output = lib2def.getnm(
             lib2def.DEFAULT_NM.split() + [lib_file], shell=False)
     dlist, flist = lib2def.parse_nm(nm_output)
-    lib2def.output_def(dlist, flist, lib2def.DEF_HEADER, open(def_file, 'w'))
+    with open(def_file, 'w') as fid:
+        lib2def.output_def(dlist, flist, lib2def.DEF_HEADER, fid)
 
     dll_name = find_python_dll ()
 
@@ -510,8 +511,7 @@ def _build_import_library_x86():
            "--dllname", dll_name,
            "--def", def_file,
            "--output-lib", out_file]
-    status = subprocess.call(cmd)
-    # for now, fail silently
+    status = subprocess.check_output(cmd)
     if status:
         log.warn('Failed to build import library for gcc. Linking will fail.')
     return
@@ -544,6 +544,8 @@ if sys.platform == 'win32':
         # Value from msvcrt.CRT_ASSEMBLY_VERSION under Python 3.3.0
         # on Windows XP:
         _MSVCRVER_TO_FULLVER['100'] = "10.0.30319.460"
+        # Python 3.7 uses 1415, but get_build_version returns 140 ??
+        _MSVCRVER_TO_FULLVER['140'] = "14.15.26726.0"
         if hasattr(msvcrt, "CRT_ASSEMBLY_VERSION"):
             major, minor, rest = msvcrt.CRT_ASSEMBLY_VERSION.split(".", 2)
             _MSVCRVER_TO_FULLVER[major + minor] = msvcrt.CRT_ASSEMBLY_VERSION

--- a/numpy/distutils/tests/test_mingw32ccompiler.py
+++ b/numpy/distutils/tests/test_mingw32ccompiler.py
@@ -8,6 +8,10 @@ from numpy.distutils import mingw32ccompiler
 
 @pytest.mark.skipif(sys.platform != 'win32', reason='win32 only test')
 def test_build_import():
+    '''Test the mingw32ccompiler.build_import_library, which builds a
+    `python.a` from the MSVC `python.lib`
+    '''
+
     # make sure `nm.exe` exists and supports the current python version. This
     # can get mixed up when the PATH has a 64-bit nm but the python is 32-bit
     try:
@@ -21,7 +25,7 @@ def test_build_import():
     elif b'pe-x86-64' not in supported:
             raise ValueError("'nm.exe' found but it does not support 64-bit"
                              "dlls when using 64-bit python")
-    # Hide the import library to force it being built
+    # Hide the import library to force a build
     has_import_lib, fullpath = mingw32ccompiler._check_for_import_lib()
     if has_import_lib: 
         shutil.move(fullpath, fullpath + '.bak')
@@ -29,6 +33,7 @@ def test_build_import():
     try: 
         # Whew, now we can actually test the function
         mingw32ccompiler.build_import_library()
+
     finally:
         if has_import_lib:
             shutil.move(fullpath + '.bak', fullpath)

--- a/numpy/distutils/tests/test_mingw32ccompiler.py
+++ b/numpy/distutils/tests/test_mingw32ccompiler.py
@@ -1,0 +1,34 @@
+import shutil
+import subprocess
+import sys
+import pytest
+
+from numpy.distutils import mingw32ccompiler
+
+
+@pytest.mark.skipif(sys.platform != 'win32', reason='win32 only test')
+def test_build_import():
+    # make sure `nm.exe` exists and supports the current python version. This
+    # can get mixed up when the PATH has a 64-bit nm but the python is 32-bit
+    try:
+        out = subprocess.check_output(['nm.exe', '--help'])
+    except FileNotFoundError:
+        pytest.skip("'nm.exe' not on path, is mingw installed?")
+    supported = out[out.find(b'supported targets:'):]
+    if sys.maxsize < 2**32 and b'pe-i386' not in supported:
+            raise ValueError("'nm.exe' found but it does not support 32-bit"
+                             "dlls when using 32-bit python")
+    elif b'pe-x86-64' not in supported:
+            raise ValueError("'nm.exe' found but it does not support 64-bit"
+                             "dlls when using 64-bit python")
+    # Hide the import library to force it being built
+    has_import_lib, fullpath = mingw32ccompiler._check_for_import_lib()
+    if has_import_lib: 
+        shutil.move(fullpath, fullpath + '.bak')
+
+    try: 
+        # Whew, now we can actually test the function
+        mingw32ccompiler.build_import_library()
+    finally:
+        if has_import_lib:
+            shutil.move(fullpath + '.bak', fullpath)


### PR DESCRIPTION
part of numpy/numpy#15714. The test should run as part of Windows CI since we install the mingw compilers, so we should check that it is not skipped.