### PR TITLE
DEP: deprecate the NPY_SIZEOF_PYARRAYOBJECT macro

### DIFF
--- a/doc/release/upcoming_changes/16938.c_api.rst
+++ b/doc/release/upcoming_changes/16938.c_api.rst
@@ -2,11 +2,12 @@ Size of ``np.ndarray`` and ``np.void_`` changed
 -----------------------------------------------
 The size of the ``PyArrayObject`` and ``PyVoidScalarObject``
 structures have changed.  The following header definition has been
-removed::
+deprecated::
 
     #define NPY_SIZEOF_PYARRAYOBJECT (sizeof(PyArrayObject_fields))
 
-since the size must not be considered a compile time constant.
+since the size must not be considered a compile time constant: it will
+change for different runtime versions of NumPy.
 
 The most likely relevant use are potential subclasses written in C which
 will have to be recompiled and should be updated.  Please see the

--- a/numpy/core/include/numpy/ndarraytypes.h
+++ b/numpy/core/include/numpy/ndarraytypes.h
@@ -721,6 +721,12 @@ typedef struct tagPyArrayObject {
 } PyArrayObject;
 #endif
 
+/* 2020-Nov-25 1.20 */
+#define NPY_SIZEOF_PYARRAYOBJECT \
+    (DEPRECATE("NPY_SIZEOF_PYARRAYOBJECT is deprecated since it cannot be used at compile time " \
+     "and is not constant across different runtime versions of NumPy\n")<0? -1: PyArray_Type.tp_basicsize)
+
+
 
 /* Array Flags Object */
 typedef struct PyArrayFlagsObject {

--- a/numpy/core/src/multiarray/_multiarray_tests.c.src
+++ b/numpy/core/src/multiarray/_multiarray_tests.c.src
@@ -2167,6 +2167,17 @@ run_intp_converter(PyObject* NPY_UNUSED(self), PyObject *args)
     return tup;
 }
 
+static PyObject *
+test_macro(PyObject* NPY_UNUSED(self), PyObject *args)
+{
+    int ret = NPY_SIZEOF_PYARRAYOBJECT;
+    if (ret < 0) {
+        return NULL;
+    }
+    return PyLong_FromLong(ret);
+}
+
+
 static PyMethodDef Multiarray_TestsMethods[] = {
     {"IsPythonScalar",
         IsPythonScalar,
@@ -2347,6 +2358,9 @@ static PyMethodDef Multiarray_TestsMethods[] = {
         METH_VARARGS, NULL},
     {"run_intp_converter",
         run_intp_converter,
+        METH_VARARGS, NULL},
+    {"test_macro",
+        test_macro,
         METH_VARARGS, NULL},
     {NULL, NULL, 0, NULL}        /* Sentinel */
 };

--- a/numpy/core/tests/test_deprecations.py
+++ b/numpy/core/tests/test_deprecations.py
@@ -771,3 +771,10 @@ class TestDeprecateSubarrayDTypeDuringArrayCoercion(_DeprecationTestCase):
                 np.array(arr, dtype="(2,2)f")
 
         self.assert_deprecated(check)
+
+class TestMacros(_DeprecationTestCase):
+    # 2020-11-25
+    def test_macro(self):
+        from numpy.core._multiarray_tests import test_macro
+        assert_(test_macro() > 32)
+        self.assert_deprecated(test_macro)


### PR DESCRIPTION
One way we could deprecate the macro. It is a bit complicated since under some warning filters, `DEPRECATE` becomes an error so we must be able to have an error sentinel for the macro.
