### PR TITLE
Make dtype version mismatch exception more descriptive.

### DIFF
--- a/numpy/core/include/numpy/experimental_dtype_api.h
+++ b/numpy/core/include/numpy/experimental_dtype_api.h
@@ -218,9 +218,10 @@ static int
 import_experimental_dtype_api(int version)
 {
     if (version != __EXPERIMENTAL_DTYPE_VERSION) {
-        PyErr_SetString(PyExc_RuntimeError,
+        PyErr_Format(PyExc_RuntimeError,
                 "DType API version %d did not match header version %d. Please "
-                "update the import statement and check for API changes.");
+                "update the import statement and check for API changes.",
+                version, __EXPERIMENTAL_DTYPE_VERSION);
         return -1;
     }
     if (__experimental_dtype_api_table != __uninitialized_table) {


### PR DESCRIPTION
Given that I'm proposing improved error messages you can probably get a sense for how my experiment is going :)