### PR TITLE
Some tests for control character collisions.

### DIFF
--- a/numpy/core/src/multiarray/textreading/readtext.c
+++ b/numpy/core/src/multiarray/textreading/readtext.c
@@ -165,8 +165,8 @@ error_if_matching_control_characters(
   error:
     if (control_char2 != NULL) {
         PyErr_Format(PyExc_TypeError,
-                "control characters '%s' and '%s' are identical, please set one"
-                "of them to `None` to indicate that it should not be used.",
+                "The values for control characters '%s' and '%s' are "
+                "incompatible",
                 control_char1, control_char2);
     }
     else {

--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -920,12 +920,6 @@ def _read(fname, *, delimiter=',', comment='#', quote='"',
 
     if comment is None:
         comments = None
-    elif isinstance(comment, str):
-        if len(comment) > 1:  # length of 0 is rejected later
-            comments = (comment,)
-            comment = None
-        else:
-            comments = None
     else:
         # assume comments are a sequence of strings
         comments = tuple(comment)
@@ -938,6 +932,13 @@ def _read(fname, *, delimiter=',', comment='#', quote='"',
             if isinstance(comments[0], str) and len(comments[0]) == 1:
                 comment = comments[0]
                 comments = None
+        else:
+            # Input validation if there are multiple comment characters
+            if delimiter in comments:
+                raise TypeError(
+                    f"Comment characters '{comments}' cannot include the "
+                    f"delimiter '{delimiter}'"
+                )
 
     # comment is now either a 1 or 0 character string or a tuple:
     if comments is not None:

--- a/numpy/lib/tests/test_loadtxt.py
+++ b/numpy/lib/tests/test_loadtxt.py
@@ -875,32 +875,27 @@ class TestCReaderUnitTests:
 
 
 def test_delimiter_comment_collision_raises():
-    #NOTE: match= TBD
-    with pytest.raises(ValueError):
+    with pytest.raises(TypeError, match="control characters.*are identical"):
         np.loadtxt(StringIO("1, 2, 3"), delimiter=",", comments=",")
 
 
 def test_delimiter_quotechar_collision_raises():
-    #NOTE: match= TBD
-    with pytest.raises(ValueError):
+    with pytest.raises(TypeError, match="control characters.*are identical"):
         np.loadtxt(StringIO("1, 2, 3"), delimiter=",", quotechar=",")
 
 
 def test_comment_quotechar_collision_raises():
-    #NOTE: match= TBD
-    with pytest.raises(ValueError):
+    with pytest.raises(TypeError, match="control characters.*are identical"):
         np.loadtxt(StringIO("1 2 3"), comments="#", quotechar="#")
 
 
 def test_delimiter_multichar_comment_collision_raises():
-    #NOTE: match= TBD
-    with pytest.raises(ValueError):
+    with pytest.raises(TypeError, match="control characters.*are identical"):
         np.loadtxt(StringIO("1, 2, 3"), delimiter=",", comments="#,")
 
 
 def test_delimiter_and_multiple_comments_collision_raises():
-    #NOTE: match= TBD
-    with pytest.raises(ValueError):
+    with pytest.raises(TypeError, match="control characters.*are identical"):
         np.loadtxt(StringIO("1, 2, 3"), delimiter=",", comments=["#", ","])
 
 
@@ -915,25 +910,18 @@ def test_delimiter_and_multiple_comments_collision_raises():
     )
 )
 def test_collision_with_default_delimiter_raises(ws):
-    #NOTE: match= TBD
-    with pytest.raises(ValueError):
+    with pytest.raises(TypeError, match="control characters.*are identical"):
         np.loadtxt(StringIO(f"1{ws}2{ws}3\n4{ws}5{ws}6\n"), comments=ws)
-    #NOTE: match= TBD
-    with pytest.raises(ValueError):
+    with pytest.raises(TypeError, match="control characters.*are identical"):
         np.loadtxt(StringIO(f"1{ws}2{ws}3\n4{ws}5{ws}6\n"), quotechar=ws)
 
 
-@pytest.mark.parametrize("nl", ("\n", "\r\n", "\r"))
-def test_delimiter_newline(nl):
+@pytest.mark.parametrize("nl", ("\n", "\r"))
+def test_control_character_newline_raises(nl):
     txt = StringIO(f"1{nl}2{nl}3{nl}{nl}4{nl}5{nl}6{nl}{nl}")
-    a = np.loadtxt(txt, delimiter=nl)
-    assert_array_equal(a, [1, 2, 3, 4, 5, 6])
-
-
-@pytest.mark.parametrize("n1", ("\n", "\r\n", "\r"))
-@pytest.mark.parametrize("n2", ("\n", "\r\n", "\r"))
-def test_delimiter_comment_both_newline_raises(n1, n2):
-    txt = StringIO(f"1{n1}2{n1}3{n1}{n1}4{n1}5{n1}6{n1}{n1}")
-    #NOTE: match= TBD
-    with pytest.raises(ValueError):
-        np.loadtxt(txt, delimiter=n1, comments=n2)
+    with pytest.raises(TypeError, match="control character.*cannot be a newline"):
+        np.loadtxt(txt, delimiter=nl)
+    with pytest.raises(TypeError, match="control character.*cannot be a newline"):
+        np.loadtxt(txt, comments=nl)
+    with pytest.raises(TypeError, match="control character.*cannot be a newline"):
+        np.loadtxt(txt, quotechar=nl)

--- a/numpy/lib/tests/test_loadtxt.py
+++ b/numpy/lib/tests/test_loadtxt.py
@@ -872,3 +872,68 @@ class TestCReaderUnitTests:
             data, dtype=np.dtype("U10"), filelike=True,
             quote='"', comment="#", skiplines=1)
         assert_array_equal(res[:, 0], ["1", f"2{newline}", "3", "4 "])
+
+
+def test_delimiter_comment_collision_raises():
+    #NOTE: match= TBD
+    with pytest.raises(ValueError):
+        np.loadtxt(StringIO("1, 2, 3"), delimiter=",", comments=",")
+
+
+def test_delimiter_quotechar_collision_raises():
+    #NOTE: match= TBD
+    with pytest.raises(ValueError):
+        np.loadtxt(StringIO("1, 2, 3"), delimiter=",", quotechar=",")
+
+
+def test_comment_quotechar_collision_raises():
+    #NOTE: match= TBD
+    with pytest.raises(ValueError):
+        np.loadtxt(StringIO("1 2 3"), comments="#", quotechar="#")
+
+
+def test_delimiter_multichar_comment_collision_raises():
+    #NOTE: match= TBD
+    with pytest.raises(ValueError):
+        np.loadtxt(StringIO("1, 2, 3"), delimiter=",", comments="#,")
+
+
+def test_delimiter_and_multiple_comments_collision_raises():
+    #NOTE: match= TBD
+    with pytest.raises(ValueError):
+        np.loadtxt(StringIO("1, 2, 3"), delimiter=",", comments=["#", ","])
+
+
+@pytest.mark.parametrize(
+    "ws",
+    (
+        " ",  # space
+        "\t",  # tab
+        "\u2003",  # em
+        "\u00A0",  # non-break
+        "\u3000",  # ideographic space
+    )
+)
+def test_collision_with_default_delimiter_raises(ws):
+    #NOTE: match= TBD
+    with pytest.raises(ValueError):
+        np.loadtxt(StringIO(f"1{ws}2{ws}3\n4{ws}5{ws}6\n"), comments=ws)
+    #NOTE: match= TBD
+    with pytest.raises(ValueError):
+        np.loadtxt(StringIO(f"1{ws}2{ws}3\n4{ws}5{ws}6\n"), quotechar=ws)
+
+
+@pytest.mark.parametrize("nl", ("\n", "\r\n", "\r"))
+def test_delimiter_newline(nl):
+    txt = StringIO(f"1{nl}2{nl}3{nl}{nl}4{nl}5{nl}6{nl}{nl}")
+    a = np.loadtxt(txt, delimiter=nl)
+    assert_array_equal(a, [1, 2, 3, 4, 5, 6])
+
+
+@pytest.mark.parametrize("n1", ("\n", "\r\n", "\r"))
+@pytest.mark.parametrize("n2", ("\n", "\r\n", "\r"))
+def test_delimiter_comment_both_newline_raises(n1, n2):
+    txt = StringIO(f"1{n1}2{n1}3{n1}{n1}4{n1}5{n1}6{n1}{n1}")
+    #NOTE: match= TBD
+    with pytest.raises(ValueError):
+        np.loadtxt(txt, delimiter=n1, comments=n2)

--- a/numpy/lib/tests/test_loadtxt.py
+++ b/numpy/lib/tests/test_loadtxt.py
@@ -895,7 +895,9 @@ def test_delimiter_multichar_comment_collision_raises():
 
 
 def test_delimiter_and_multiple_comments_collision_raises():
-    with pytest.raises(TypeError, match="control characters.*are identical"):
+    with pytest.raises(
+        TypeError, match="Comment characters.*cannot include the delimiter"
+    ):
         np.loadtxt(StringIO("1, 2, 3"), delimiter=",", comments=["#", ","])
 
 

--- a/numpy/lib/tests/test_loadtxt.py
+++ b/numpy/lib/tests/test_loadtxt.py
@@ -889,11 +889,6 @@ def test_comment_quotechar_collision_raises():
         np.loadtxt(StringIO("1 2 3"), comments="#", quotechar="#")
 
 
-def test_delimiter_multichar_comment_collision_raises():
-    with pytest.raises(TypeError, match="control characters.*are identical"):
-        np.loadtxt(StringIO("1, 2, 3"), delimiter=",", comments="#,")
-
-
 def test_delimiter_and_multiple_comments_collision_raises():
     with pytest.raises(
         TypeError, match="Comment characters.*cannot include the delimiter"

--- a/numpy/lib/tests/test_loadtxt.py
+++ b/numpy/lib/tests/test_loadtxt.py
@@ -491,6 +491,8 @@ def test_invalid_converter(conv):
         np.loadtxt(StringIO("1 2\n3 4"), converters=conv)
 
 
+@pytest.mark.skipif(IS_PYPY and sys.implementation.version <= (7, 3, 8),
+                    reason="PyPy bug in error formatting")
 def test_converters_dict_raises_non_integer_key():
     with pytest.raises(TypeError, match="keys of the converters dict"):
         np.loadtxt(StringIO("1 2\n3 4"), converters={"a": int})


### PR DESCRIPTION
Adds some tests for the behavior of control characters, e.g. `comments`, `delimiter` and `quotechar`, when they have the same value. At this stage, these tests are more to frame the discussion about what the behavior *should* be, not to test what it currently is. I personally think raising an exception is correct for most of these situations, though it's worth noting that `np.loadtxt` currently doesn't for most of these corner cases (and seems to randomly assign precedence to `delimiter` over `comments` or vice versa depending on the values).

I've also added a test for `delimiter=<newline>`, and things get a little fuzzy when you start mixing/combining `\r` and `\n`.

As mentioned, these tests are intended to be discussion points, so feel free to modify/delete any that are nonsensical or overly strict. They're by no means complete either!