### PR TITLE
Additional tests to close out remaining `additionalTests` tagged issues

### DIFF
--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -922,6 +922,11 @@ def _read(fname, *, delimiter=',', comment='#', quote='"',
         comments = None
     else:
         # assume comments are a sequence of strings
+        if "" in comment:
+            raise ValueError(
+                "comments cannot be an empty string. Use comments=None to "
+                "disable comments."
+            )
         comments = tuple(comment)
         comment = None
         if len(comments) == 0:

--- a/numpy/lib/tests/test_loadtxt.py
+++ b/numpy/lib/tests/test_loadtxt.py
@@ -928,16 +928,26 @@ def test_control_character_newline_raises(nl):
         np.loadtxt(txt, quotechar=nl)
 
 
-def test_datetime_parametric_unit_discovery():
+@pytest.mark.parametrize(
+    ("generic_data", "long_datum", "unitless_dtype", "expected_dtype"),
+    [
+        ("2012-03", "2013-01-15", "M8", "M8[D]"),  # Datetimes
+        ("spam-a-lot", "tis_but_a_scratch", "U", "U17"),  # str
+    ],
+)
+@pytest.mark.parametrize("nrows", (10, 50000, 60000))  # lt, eq, gt chunksize
+def test_datetime_parametric_unit_discovery(
+    generic_data, long_datum, unitless_dtype, expected_dtype, nrows
+):
     """Check that the correct unit (e.g. month, day, second) is discovered from
     the data when a user specifies a unitless datetime."""
     # Unit should be "D" (days) due to last entry
-    data = ["2012-03"] * 50000 + ["2013-01-15"]
-    expected = np.array(data, dtype="M8[D]")
+    data = [generic_data] * 50000 + [long_datum]
+    expected = np.array(data, dtype=expected_dtype)
 
     # file-like path
     txt = StringIO("\n".join(data))
-    a = np.loadtxt(txt, dtype="M8")
+    a = np.loadtxt(txt, dtype=unitless_dtype)
     assert a.dtype == expected.dtype
     assert_equal(a, expected)
 
@@ -945,6 +955,6 @@ def test_datetime_parametric_unit_discovery():
     fd, fname = mkstemp()
     with open(fname, "w") as fh:
         fh.write("\n".join(data))
-    a = np.loadtxt(fname, dtype="M8")
+    a = np.loadtxt(fname, dtype=unitless_dtype)
     assert a.dtype == expected.dtype
     assert_equal(a, expected)

--- a/numpy/lib/tests/test_loadtxt.py
+++ b/numpy/lib/tests/test_loadtxt.py
@@ -936,7 +936,7 @@ def test_control_character_newline_raises(nl):
     ],
 )
 @pytest.mark.parametrize("nrows", (10, 50000, 60000))  # lt, eq, gt chunksize
-def test_datetime_parametric_unit_discovery(
+def test_parametric_unit_discovery(
     generic_data, long_datum, unitless_dtype, expected_dtype, nrows
 ):
     """Check that the correct unit (e.g. month, day, second) is discovered from
@@ -956,6 +956,28 @@ def test_datetime_parametric_unit_discovery(
     with open(fname, "w") as fh:
         fh.write("\n".join(data))
     a = np.loadtxt(fname, dtype=unitless_dtype)
+    assert a.dtype == expected.dtype
+    assert_equal(a, expected)
+
+
+def test_str_dtype_unit_discovery_with_converter():
+    data = ["spam-a-lot"] * 60000 + ["XXXtis_but_a_scratch"]
+    expected = np.array(
+        ["spam-a-lot"] * 60000 + ["tis_but_a_scratch"], dtype="U17"
+    )
+    conv = lambda s: s.strip("XXX")
+
+    # file-like path
+    txt = StringIO("\n".join(data))
+    a = np.loadtxt(txt, dtype="U", converters=conv, encoding=None)
+    assert a.dtype == expected.dtype
+    assert_equal(a, expected)
+
+    # file-obj path
+    fd, fname = mkstemp()
+    with open(fname, "w") as fh:
+        fh.write("\n".join(data))
+    a = np.loadtxt(fname, dtype="U", converters=conv, encoding=None)
     assert a.dtype == expected.dtype
     assert_equal(a, expected)
 

--- a/numpy/lib/tests/test_loadtxt.py
+++ b/numpy/lib/tests/test_loadtxt.py
@@ -958,3 +958,14 @@ def test_datetime_parametric_unit_discovery(
     a = np.loadtxt(fname, dtype=unitless_dtype)
     assert a.dtype == expected.dtype
     assert_equal(a, expected)
+
+
+def test_control_character_empty():
+    with pytest.raises(TypeError, match="Text reading control character must"):
+        np.loadtxt(StringIO("1 2 3"), delimiter="")
+    with pytest.raises(TypeError, match="Text reading control character must"):
+        np.loadtxt(StringIO("1 2 3"), quotechar="")
+    with pytest.raises(ValueError, match="comments cannot be an empty string"):
+        np.loadtxt(StringIO("1 2 3"), comments="")
+    with pytest.raises(ValueError, match="comments cannot be an empty string"):
+        np.loadtxt(StringIO("1 2 3"), comments=["#", ""])


### PR DESCRIPTION
Adds some scattered remaining tests to address remaining bids-numpy/npreadtext issues.

Re: `comments=""` - I added a check to match the behavior of numpy 1.22 (which raises a `ValueError`) with a better (IMO) exception message.