### PR TITLE
PoC,WIP: Proof of concept for extending buffer protocol string

### DIFF
--- a/numpy/__init__.cython-30.pxd
+++ b/numpy/__init__.cython-30.pxd
@@ -7,6 +7,8 @@
 # Author: Dag Sverre Seljebotn
 #
 
+cimport cython
+
 from cpython.ref cimport Py_INCREF
 from cpython.object cimport PyObject, PyTypeObject, PyObject_TypeCheck
 cimport libc.stdio as stdio
@@ -1221,6 +1223,7 @@ cdef extern from "numpy/ndarraytypes.h":
     ctypedef struct npy_string_allocator:
         pass
 
+    @cython.extended_buffer_regex("numpy", r"numpy.dtypes.StringDType:[\da-f]+")
     ctypedef struct npy_packed_static_string:
         pass
 

--- a/numpy/_core/src/multiarray/buffer.c
+++ b/numpy/_core/src/multiarray/buffer.c
@@ -18,6 +18,8 @@
 #include "arrayobject.h"
 #include "scalartypes.h"
 #include "dtypemeta.h"
+#include "descriptor.h"
+#include "_datetime.h"
 
 /*************************************************************************
  ****************   Implement Buffer Protocol ****************************
@@ -417,6 +419,21 @@ _buffer_format_string(PyArray_Descr *descr, _tmp_string_t *str,
             /* Insert padding bytes */
             char buf[128];
             PyOS_snprintf(buf, sizeof(buf), "%" NPY_INTP_FMT "x", descr->elsize);
+            if (_append_str(str, buf) < 0) return -1;
+            break;
+        }
+        case NPY_TIMEDELTA: {
+            char buf[128];
+            PyArray_DatetimeMetaData *meta = get_datetime_metadata_from_dtype(descr);
+            PyOS_snprintf(buf, sizeof(buf), "[numpy$numpy.dtypes:TimeDelta64DType:%x:%x]",
+                          meta->base, meta->num);
+            if (_append_str(str, buf) < 0) return -1;
+            break;
+        }
+        case NPY_VSTRING: {
+            char buf[128];
+            PyOS_snprintf(buf, sizeof(buf), "[numpy$numpy.dtypes:StringDType:%zx]",
+                          (Py_uintptr_t)descr);
             if (_append_str(str, buf) < 0) return -1;
             break;
         }

--- a/numpy/_core/src/multiarray/ctors.c
+++ b/numpy/_core/src/multiarray/ctors.c
@@ -1806,26 +1806,27 @@ PyArray_CheckFromAny(PyObject *op, PyArray_Descr *descr, int min_depth,
  * Internal version of PyArray_CheckFromAny that accepts a dtypemeta. Borrows
  * references to the descriptor and dtype.
  */
-
 NPY_NO_EXPORT PyObject *
 PyArray_CheckFromAny_int(PyObject *op, PyArray_Descr *in_descr,
                          PyArray_DTypeMeta *in_DType, int min_depth,
                          int max_depth, int requires, PyObject *context)
 {
     PyObject *obj;
+    Py_XINCREF(in_descr);  /* take ownership as we may replace it */
     if (requires & NPY_ARRAY_NOTSWAPPED) {
         if (!in_descr && PyArray_Check(op)) {
             in_descr = PyArray_DESCR((PyArrayObject *)op);
-            Py_INCREF(in_descr);
         }
-        if (in_descr) {
-            PyArray_DESCR_REPLACE_CANONICAL(in_descr);
+        PyArray_DESCR_REPLACE_CANONICAL(in_descr);
+        if (in_descr == NULL) {
+            return NULL;
         }
     }
 
     int was_scalar;
     obj = PyArray_FromAny_int(op, in_descr, in_DType, min_depth,
                               max_depth, requires, context, &was_scalar);
+    Py_XDECREF(in_descr);
     if (obj == NULL) {
         return NULL;
     }

--- a/numpy/_core/src/multiarray/item_selection.c
+++ b/numpy/_core/src/multiarray/item_selection.c
@@ -2127,7 +2127,6 @@ PyArray_SearchSorted(PyArrayObject *op1, PyObject *op2,
     if (dtype == NULL) {
         return NULL;
     }
-    /* refs to dtype we own = 1 */
 
     /* Look for binary search function */
     if (perm) {
@@ -2138,26 +2137,20 @@ PyArray_SearchSorted(PyArrayObject *op1, PyObject *op2,
     }
     if (binsearch == NULL && argbinsearch == NULL) {
         PyErr_SetString(PyExc_TypeError, "compare not supported for type");
-        /* refs to dtype we own = 1 */
         Py_DECREF(dtype);
-        /* refs to dtype we own = 0 */
         return NULL;
     }
 
-    /* need ap2 as contiguous array and of right type */
-    /* refs to dtype we own = 1 */
-    Py_INCREF(dtype);
-    /* refs to dtype we own = 2 */
+    /* need ap2 as contiguous array and of right dtype (steals and may be replace it) */
     ap2 = (PyArrayObject *)PyArray_CheckFromAny(op2, dtype,
                                 0, 0,
                                 NPY_ARRAY_CARRAY_RO | NPY_ARRAY_NOTSWAPPED,
                                 NULL);
-    /* refs to dtype we own = 1, array creation steals one even on failure */
     if (ap2 == NULL) {
-        Py_DECREF(dtype);
-        /* refs to dtype we own = 0 */
         return NULL;
     }
+    /* dtype was stolen, replace it in case the array creation replaced it. */
+    dtype = (PyArray_Descr *)Py_NewRef(PyArray_DESCR(ap2));
 
     /*
      * If the needle (ap2) is larger than the haystack (op1) we copy the
@@ -2166,9 +2159,9 @@ PyArray_SearchSorted(PyArrayObject *op1, PyObject *op2,
     if (PyArray_SIZE(ap2) > PyArray_SIZE(op1)) {
         ap1_flags |= NPY_ARRAY_CARRAY_RO;
     }
+    /* dtype is stolen, after this we have no reference */
     ap1 = (PyArrayObject *)PyArray_CheckFromAny((PyObject *)op1, dtype,
                                 1, 1, ap1_flags, NULL);
-    /* refs to dtype we own = 0, array creation steals one even on failure */
     if (ap1 == NULL) {
         goto fail;
     }

--- a/numpy/_core/tests/test_cython.py
+++ b/numpy/_core/tests/test_cython.py
@@ -329,6 +329,14 @@ def test_npystring_multiple_allocators(install_temp):
     assert arr1[-1] is None
     assert arr2[0] == "test this"
 
+def test_pystring_pack_mview(install_temp):
+    """Test basic memoryview interface"""
+    import checks
+
+    dt = np.dtypes.StringDType(na_object=None)
+    arr = np.array(['abcd', 'b', 'c'], dtype=dt)
+    checks.npystring_write_memview(arr)
+    assert (arr == "Hello world, hello Pythonistas").all()
 
 def test_npystring_allocators_other_dtype(install_temp):
     """Check that allocators for non-StringDType arrays is NULL."""

--- a/numpy/_core/tests/test_regression.py
+++ b/numpy/_core/tests/test_regression.py
@@ -2652,3 +2652,9 @@ class TestRegression:
         inp = np.linspace(0, size, num=size, dtype=np.intc)
         out = np.sort(inp)
         assert_equal(inp, out)
+
+    def test_searchsorted_structured(self):
+        # gh-28190
+        x = np.array([(0, 1.)], dtype=[('time', '<i8'), ('value', '<f8')])
+        y = np.array((0, 0.), dtype=[('time', '<i8'), ('value', '<f8')])
+        x.searchsorted(y)


### PR DESCRIPTION
This is a proof of concept, that allows roundtripping code such as:
```
a = np.arange(100000).astype("T")
print(memoryview(a).format)  # just to see it
via_memview_string = np.asarray(memoryview(a))

a = np.arange(1000).astype("m8[ms]")  # or even struct "m8[...],i"
print(memoryview(a).format)  # just to see it
via_memview_timedelta = np.asarray(memoryview(a))
```
As well as a PoC for basic Cython exposure as a typed memory-view (see below).

I opted to simply store the `descr` pointer directly.  This seems just as well because the descr owns the side-car buffer. One could still export it to non-Python (somewhat) since accessing that side-car buffer _doesn't_ need Python API in the end (just struct layout information).

For the times I opted to store two hex ints.  From Python that is awkward, but our time enum is public anyway.  (But we could also store `ns`, etc. strings.)

---

Note: This branch shows a minimal PoC extension to access NumPy string arrays via Cython (these are particularly difficulty, because one needs the allocator to access elements).
Because of this, it requires using this branch of Cython https://github.com/da-woods/cython/pull/5